### PR TITLE
pinning to main in order to allow 1.0.0 release to be created

### DIFF
--- a/.github/workflows/auto-release-reusable.yml
+++ b/.github/workflows/auto-release-reusable.yml
@@ -25,7 +25,7 @@ jobs:
   auto-release:
     runs-on: ubuntu-latest
     steps:
-    - uses: cloudposse/github-action-auto-release@1.0.0
+    - uses: cloudposse/github-action-auto-release@main
       with:
         actions-files-checkout-path: ${{ inputs.actions-files-checkout-path }}
         prerelease: ${{ inputs.prerelease }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -13,7 +13,7 @@ jobs:
     # For development reasons, this action is pinned to the `main` branch.
     # However, we recommend that you choose a specific release to pin to.
     # Consult https://github.com/cloudposse/github-action-auto-release/releases for a list of available releases.
-    uses: cloudposse/github-action-auto-release/.github/workflows/auto-release-reusable.yml@1.0.0
+    uses: cloudposse/github-action-auto-release/.github/workflows/auto-release-reusable.yml@main
     with:
       actions-files-checkout-path: github-action-auto-release
       prerelease: false


### PR DESCRIPTION
## what
* Want to create 1.0.0 release. Need to merge this PR with `major` tag to do that.

## why
* This will allow other repos using this action to pin to a `1.0` version.