### PR TITLE
pinning to 1.0.0

### DIFF
--- a/.github/workflows/auto-release-reusable.yml
+++ b/.github/workflows/auto-release-reusable.yml
@@ -25,7 +25,7 @@ jobs:
   auto-release:
     runs-on: ubuntu-latest
     steps:
-    - uses: cloudposse/github-action-auto-release@main
+    - uses: cloudposse/github-action-auto-release@1.0.0
       with:
         actions-files-checkout-path: ${{ inputs.actions-files-checkout-path }}
         prerelease: ${{ inputs.prerelease }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -13,7 +13,7 @@ jobs:
     # For development reasons, this action is pinned to the `main` branch.
     # However, we recommend that you choose a specific release to pin to.
     # Consult https://github.com/cloudposse/github-action-auto-release/releases for a list of available releases.
-    uses: cloudposse/github-action-auto-release/.github/workflows/auto-release-reusable.yml@main
+    uses: cloudposse/github-action-auto-release/.github/workflows/auto-release-reusable.yml@1.0.0
     with:
       actions-files-checkout-path: github-action-auto-release
       prerelease: false


### PR DESCRIPTION
## what
* Now that we have a `1.0.0` release, we're pinning the version of `.github/workflows/auto-release.yml` in the `main` branch to it.

## why
* This way, new adopters of the `github-action-auto-release` action will, by default (assuming they use the copy-paste `.github/workflows/auto-release.yml` workflow file), use a specific version of the action, instead of whatever the most recent commit is in `main`.