### PR TITLE
ok, pinning the auto-release action to main

### DIFF
--- a/.github/workflows/auto-release-reusable.yml
+++ b/.github/workflows/auto-release-reusable.yml
@@ -25,7 +25,7 @@ jobs:
   auto-release:
     runs-on: ubuntu-latest
     steps:
-    - uses: cloudposse/github-action-auto-release@1.0.0
+    - uses: cloudposse/github-action-auto-release@main
       with:
         actions-files-checkout-path: ${{ inputs.actions-files-checkout-path }}
         prerelease: ${{ inputs.prerelease }}

--- a/docs/auto-release.yml
+++ b/docs/auto-release.yml
@@ -39,8 +39,7 @@ change-template: |
   <details>
     <summary>$TITLE @$AUTHOR (#$NUMBER)</summary>
 
-  TEST HEADING --
-  $BODY
+    $BODY
   </details>
 
 template: |


### PR DESCRIPTION
## what
* Pinning `auto-release-reusable.yml` to `main`

## why
* To debug release notes formatting