### PR TITLE
bumping release-drafter action version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
         cat ./${{ inputs.actions-files-checkout-path }}/docs/auto-release.yml || echo "original file not found"
 
     # Drafts the next Release and compiles the notes as Pull Requests are merged into "main" (unless the `no-release` label is used on the PR)
-    - uses: release-drafter/release-drafter@v5
+    - uses: release-drafter/release-drafter@v5.20.0
       with:
         publish: ${{ inputs.publish || !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') }}
         prerelease: ${{ inputs.prerelease }}


### PR DESCRIPTION
## what
* Bumping `release-drafter/release-drafter` action version in the hopes it will allow addition of config files at action runtime.

## why
* Currently, config files can't be copied into the `.github` folder at action runtime.