### PR TITLE
cleaning up release notes template

### DIFF
--- a/.github/auto-release-config.yml
+++ b/.github/auto-release-config.yml
@@ -39,8 +39,6 @@ change-template: |
   <details>
     <summary>$TITLE @$AUTHOR (#$NUMBER)</summary>
 
-    TEST HEADING --
-
     $BODY
   </details>
 


### PR DESCRIPTION
## what
* Removing debug info from release notes template.

## why
* Moving out of debug mode, since everything's working now.
