### PR TITLE
pinning version of action call in auto-release-reusable to 1.12.0

### DIFF
--- a/.github/workflows/auto-release-reusable.yml
+++ b/.github/workflows/auto-release-reusable.yml
@@ -20,7 +20,7 @@ jobs:
   auto-release:
     runs-on: ubuntu-latest
     steps:
-    - uses: cloudposse/github-action-auto-release@main
+    - uses: cloudposse/github-action-auto-release@v1.12.0
       with:
         prerelease: ${{ inputs.prerelease }}
         publish: ${{ inputs.publish }}


### PR DESCRIPTION
## what
* Pinning `auto-release` action to `v1.12.0` in `auto-release-reusable.yml`.
* This is a stable release.

## why
* This will enable users to version pin by pinning their own copies of `auto-release.yml` (not `auto-release-reusable.yml`) to `v1.12.1`.