### PR TITLE
debugging exact syntax of version pin

### DIFF
--- a/.github/workflows/auto-release-reusable.yml
+++ b/.github/workflows/auto-release-reusable.yml
@@ -20,7 +20,7 @@ jobs:
   auto-release:
     runs-on: ubuntu-latest
     steps:
-    - uses: cloudposse/github-action-auto-release@v1.12.0
+    - uses: cloudposse/github-action-auto-release@1.12.0
       with:
         prerelease: ${{ inputs.prerelease }}
         publish: ${{ inputs.publish }}


### PR DESCRIPTION
## what
* This is a stable release.
* Pinning `auto-release-reusable.yml` workflow to `1.12.0` version of `github-action-auto-release`.

## why
* This allows users to pin their actions by changing the tag in their copies of `auto-release.yml` (not `auto-release-reusable.yml`) to `1.12.1` (not `1.12.0`).