### PR TITLE
not releasing if only changes are in README* files

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,7 +10,6 @@ on:
       - main
       - master
       - production
-  workflow_dispatch:
 
 jobs:
   auto-release:

--- a/action.yml
+++ b/action.yml
@@ -48,11 +48,12 @@ runs:
     # Drafts the next Release and compiles the notes as Pull Requests are merged into "main" (unless the `no-release` label is used on the PR)
     - uses: release-drafter/release-drafter@v5.20.0
       with:
-        # This boolean looks complicated, but it's just saying that we only publish if inputs.publish is true,
-        # or if the PR doesn't already have the no-release label and does have changes to non-README files.
-        # Unfortunately, the compound second condition is actually a relatively simple way to code this up, all things considered,
-        # since we use outputs from steps.get-merged-pull-request in steps.file-changes, meaning that we can't just switch
-        # the ordering of the action steps to avoid needing the && operator.
+        # The following boolean expression may appear complex, but its purpose is to only enable publishing if:
+        # 1. inputs.publish is true, or
+        # 2. the PR does not have the 'no-release' label and contains changes to files other than README.
+        # Due to the dependencies between steps.get-merged-pull-request and steps.file-changes, rearranging action steps
+        # is not a viable option to eliminate the use of the && operator, making this compound condition a relatively
+        # straightforward solution under the circumstances.
         publish: ${{ inputs.publish || ( !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') && !steps.file-changes.only-readme ) }}
         prerelease: ${{ inputs.prerelease }}
         config-name: auto-release-config.yml

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,11 @@ runs:
     # Drafts the next Release and compiles the notes as Pull Requests are merged into "main" (unless the `no-release` label is used on the PR)
     - uses: release-drafter/release-drafter@v5.20.0
       with:
+        # This boolean looks complicated, but it's just saying that we only publish if inputs.publish is true,
+        # or if the PR doesn't already have the no-release label and does have changes to non-README files.
+        # Unfortunately, the compound second condition is actually a relatively simple way to code this up, all things considered,
+        # since we use outputs from steps.get-merged-pull-request in steps.file-changes, meaning that we can't just switch
+        # the ordering of the action steps to avoid needing the && operator.
         publish: ${{ inputs.publish || ( !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') && !steps.file-changes.only-readme ) }}
         prerelease: ${{ inputs.prerelease }}
         config-name: auto-release-config.yml

--- a/action.yml
+++ b/action.yml
@@ -26,10 +26,29 @@ runs:
       with:
         github_token: ${{ inputs.token }}
 
+    # Get list of all changed files in PR and test whether the PR only contains changes to README.* files
+    - name: "Check for changes only being present in README.* files"
+      id: file-changes
+      shell: bash
+      runs: |
+        if [[ $(git diff --name-only --diff-filter=ACMRT | grep -c -v "README") == 0 ]]; then
+          echo "::set-output name=only-readme::true"
+        else
+          echo "::set-output name=only-readme::false"
+        fi
+
+    # Add the `no-release` label to the PR if the only changes are in README.* files
+    - name: "Don't release on README.*-only changes"
+      if: steps.file-changes.only-readme
+      uses: actions-ecosystem/action-add-labels
+      with:
+        labels: no-release
+        number: ${{ steps.get-merged-pull-request.outputs.number }}
+
     # Drafts the next Release and compiles the notes as Pull Requests are merged into "main" (unless the `no-release` label is used on the PR)
     - uses: release-drafter/release-drafter@v5.20.0
       with:
-        publish: ${{ inputs.publish || !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') }}
+        publish: ${{ inputs.publish || ( !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') && !steps.file-changes.only-readme ) }}
         prerelease: ${{ inputs.prerelease }}
         config-name: auto-release-config.yml
       env:


### PR DESCRIPTION
## what
* Adding a `no-release` label to any PR that only contains changes to `README*` files. This will prevent issuing new releases for just docs updates.
* Removing `workflow_dispatch:` trigger from `auto-release.yml` workflow, since this functionality is implicitly meant to be triggered only by PRs.

## why
* Issuing new releases for only documantation updates is unnecessary, since there is necessarily no new functionality in the release.

## references
* CPCO-441