### PR TITLE
Make release latest only for default branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -76,6 +76,7 @@ runs:
       with:
         publish: ${{ inputs.publish == 'true' && !contains(fromJson(steps.pr-info.outputs.result).labels, 'no-release')}}
         prerelease: ${{ (inputs.prerelease != '' && inputs.prerelease) || contains(fromJson(steps.pr-info.outputs.result).labels, 'prerelease') }}
+        latest: ${{ github.ref == format("ref/head/{}", github.event.repository.default_branch) }}
         config-name: ${{ inputs.config-name }}
       env:
         GITHUB_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
## what
* Set new releases as latest only if they reference the default branch

## why
* To avoid cases with release from hotfix branches marked as latest