### PR TITLE
Fix no existed  releases error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -131,8 +131,15 @@ runs:
             const release = await github.rest.repos.getReleaseByTag({
               ...repository,
               tag,
+            }).catch(function(error) {
+              if (error.status === 404) {
+                core.info(`Release v${VERSION} not found`)
+                return
+              } else {
+                throw error
+              }
             });
-            if ( ! release.data.draft && release.data.prerelease == ${{ inputs.prerelease }} ) {
+            if ( release && ! release.data.draft && release.data.prerelease == ${{ inputs.prerelease }} ) {
               console.log("Found release: " + tag);
               return true;
             }


### PR DESCRIPTION
## what
* Catch 404 errors on get release by tag

## why
* Fix getting released for custom tags

## references
* https://github.com/cloudposse-terraform-components/template/actions/runs/14774110715/job/41480433002