### PR TITLE
chore: upgrade actions to Node 24 runtime (SHA-pinned)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,12 +68,12 @@ runs:
   using: "composite"
   steps:
     - name: Checkout commit
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         token: ${{ inputs.token }}
         fetch-tags: true
 
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       name: Get PR labels
       id: pr-info
       with:
@@ -110,7 +110,7 @@ runs:
         echo "value=${tags}" >> $GITHUB_OUTPUT
 
     - name: Check for duplicates
-      uses: actions/github-script@v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       id: has-duplicate
       with:
         retries: 3
@@ -147,11 +147,12 @@ runs:
           return false;
 
     # Drafts the next Release and compiles the notes as Pull Requests are merged into "main" (unless the `no-release` label is used on the PR)
-    - uses: release-drafter/release-drafter@v6
+    - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
       name: Draft release
       id: release
       if: steps.has-duplicate.outputs.result == 'false'
       with:
+        token: ${{ inputs.token }}
         publish: ${{ inputs.publish == 'true' && !contains(fromJson(steps.pr-info.outputs.result).labels, 'no-release')}}
         prerelease: ${{ (inputs.prerelease != '' && inputs.prerelease) || contains(fromJson(steps.pr-info.outputs.result).labels, 'prerelease') }}
         latest: ${{ inputs.latest }}


### PR DESCRIPTION
## what

* Bump the composite action's references to versions running on the Node 24 runtime, SHA-pinned
  with precise version comments:
  * `actions/checkout@v4` → `@3d3c42e5...` `# v7.0.1`
  * `actions/github-script@v7` → `@3a2844b7...` `# v9.0.0` (×2)
  * `release-drafter/release-drafter@v6` → `@34d80673...` `# v7.7.0`
* Pass `token: ${{ inputs.token }}` explicitly to the release-drafter step — v7 introduces a
  `token` input (defaulting to `github.token`); passing it explicitly guarantees the bot token is
  used regardless of how future versions weigh the input vs. the `GITHUB_TOKEN` env (the env is
  kept for back-compat)

## why

* GitHub is deprecating the Node 20 runtime; steps pinned to node20 releases emit a deprecation
  warning for every consumer of this action (232 repos reference it)
* Combines and supersedes the three pending Renovate PRs (#59 checkout, #57 github-script,
  #56 release-drafter) in one reviewable change, upgraded to SHA pinning per the org's
  supply-chain direction (cloudposse/.github#261)
* Every new SHA was verified against its upstream tag, and `runs.using: node24` confirmed at each
  pinned ref
* release-drafter v6→v7 breaking changes reviewed: the removed `disable-releaser`/`disable-autolabeler`
  inputs are not used here, and the org's `auto-release*.yml` configs use none of the dropped
  config keys (`include-pre-releases`, `references`)

## references

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
* https://github.com/release-drafter/release-drafter/releases/tag/v7.0.0
* Supersedes #56, #57, #59
